### PR TITLE
fixed suspected bug of divisor/divident --> divident/divisor for dmg calc

### DIFF
--- a/RMASifterResurgencePrime/src/strainMap/StrainMisMatchContainer.java
+++ b/RMASifterResurgencePrime/src/strainMap/StrainMisMatchContainer.java
@@ -92,7 +92,7 @@ public void processMisMatches(){
 				
 					damDivident = (damDivisor+positionContainer.get("CC"));
 					
-					double d = damDivisor/damDivident;
+					double d = damDivident/damDivisor;
 					damage.put(i, d);
 				}else{
 					double d = 1.0;


### PR DESCRIPTION
Suspected bug in the calculation of damage for /results/ancient/damageMismatch

Behavior seems to overestimate % of reads showing damage when low numbers of reads are at a given node. Also seems likely that the calculation of ""background"" reads (eg divisor) should be the summed number of reads that have no C->T transition, instead of current reliance on seeing C->C transition. (This interpretation could be wrong, however.)